### PR TITLE
仮注文に関するコントローラーの作成(create)

### DIFF
--- a/app/controllers/api/v1/line_foods_controller.rb
+++ b/app/controllers/api/v1/line_foods_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  module V1
+    class LineFoodsController < ApplicationController
+      before_action :set_food, only: %i[create]
+
+      def create
+        if LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists?
+          return render json: {
+            existing_restaurant: LineFood.other_restaurant(@ordered_food.restaurant.id).first.restaurant.name,
+            new_restaurant: Food.find(params[:food_id]).restaurant.name,
+          }, status: :not_acceptable
+        end
+
+        set_line_food(@ordered_food)
+
+        if @line_food.save
+          render json: {
+            line_food: @line_food
+          }, status: :created
+        else
+          render json: {}, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def set_food
+        @ordered_food = Food.find(params[:food_id])
+      end
+
+      def set_line_food(ordered_food)
+        if ordered_food.line_food.present?
+          @line_food = ordered_food.line_food
+          @line_food.attributes = {
+            count: ordered_food.line_food.count + params[:count],
+            active: true
+          }
+        else
+          @line_food = ordered_food.build_line_food(
+            count: params[:count],
+            restaurant: ordered_food.restaurant,
+            active: true
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/rails-react-uber-eats/issues/9#issue-2443973540

## コード補足
### create アクション
```rb
def create
  if LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists?
    return render json: {
      existing_restaurant: LineFood.other_restaurant(@ordered_food.restaurant.id).first.restaurant.name,
      new_restaurant: Food.find(params[:food_id]).restaurant.name,
    }, status: :not_acceptable
  end

  set_line_food(@ordered_food)

  if @line_food.save
    render json: {
      line_food: @line_food
    }, status: :created
  else
    render json: {}, status: :internal_server_error
  end
end
```
- create アクションは、新しいラインフードアイテムを作成するための処理。
- LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists? で、
- アクティブな他のレストランのラインフードが存在するかを確認。
- 存在する場合、既存のレストランと新しいレストランの名前をJSONレスポンスで返し、ステータスを :not_acceptable に設定
- set_line_food(@ordered_food) メソッドを呼び出して、ラインフードをセット。
- ラインフードが正常に保存された場合、JSONレスポンスでラインフードの情報を返し、ステータスを :created に設定
- 保存に失敗した場合、空のJSONレスポンスと :internal_server_error のステータスを返す。

### プライベートメソッド
set_food メソッド
```rb
private

def set_food
  @ordered_food = Food.find(params[:food_id])
end
```
set_food メソッドは、params[:food_id] を使用して特定の Food オブジェクトを見つけて @ordered_food にセット。
set_line_food メソッド
```rb
def set_line_food(ordered_food)
  if ordered_food.line_food.present?
    @line_food = ordered_food.line_food
    @line_food.attributes = {
      count: ordered_food.line_food.count + params[:count],
      active: true
    }
  else
    @line_food = ordered_food.build_line_food(
      count: params[:count],
      restaurant: ordered_food.restaurant,
      active: true
    )
  end
end
```
- set_line_food メソッドは、ordered_food に関連する LineFood オブジェクトを設定。
- 既存の LineFood が存在する場合、その count を更新し、active フラグを true に。
- 既存の LineFood が存在しない場合、新しい LineFood を作成し、count、restaurant、および active フラグを設定。
このコントローラは、特定の食品に対するラインフードの作成と、他のレストランのアクティブなラインフードの存在をチェックするロジックを含んでいる。


# techpit解説
```rb
before_action :set_food, only: %i[create]
  #省略
private
  def set_food
    @ordered_food = Food.find(params[:food_id])
  end
```
createの実行前に、set_foodを実行することができる。
:onlyオプションをつけることで、特定のアクションの実行前にだけ追加すると
***set_foodはこのコントローラーの中でしか呼ばれないアクション***。そのため、privateにする

set_foodの中ではparams[:food_id]を受け取って、対応するFoodを１つ抽出し、@ordered_foodというインスタンス変数に代入。こうすることで、このあと実行されるcreateアクションの中でも@ordered_foodを参照することができる。

### 例外パターンで早期リターン
仮注文を作成する際の例外パターンは他店舗での仮注文がすでにある場合。
処理の一番最初にリターンで処理を終えるようにする。

LineFood.active.other_restaurant(@ordered_food.restaurant.id)は
複数のscope(active、other_restaurant)を組み合わせて、
「他店舗でアクティブなLineFood」をActiveRecord_Relationのかたちで取得。
そして、それが存在するかどうか？をexists?で判断。
ここでtrueにある場合には、JSON形式のデータを返却してreturnして処理を追える。

JSON形式のデータの中身にはexisting_restaurantですでに作成されている他店舗の情報と、
new_restaurantでこのリクエストで作成しようとした新店舗の情報の２つを返している。
HTTPレスポンスステータスコードは406 Not Acceptableを返す。

```rb
if LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists?
  return render json: {
    existing_restaurant: LineFood.other_restaurant(@ordered_food.restaurant.id).first.restaurant.name,
    new_restaurant: Food.find(params[:food_id]).restaurant.name,
  }, status: :not_acceptable
end
```

### line_foodインスタンスを生成
```rb
set_line_food(@ordered_food)
#省略
def set_line_food(ordered_food)
  if ordered_food.line_food.present?
    @line_food = ordered_food.line_food
    @line_food.attributes = {
      count: ordered_food.line_food.count + params[:count],
      active: true
    }
  else
    @line_food = ordered_food.build_line_food(
      count: params[:count],
      restaurant: ordered_food.restaurant,
      active: true
    )
  end
end
```
正常に仮注文を作成する場合にはset_line_food(@ordered_food)でline_foodインスタンスを生成。
ただ、ここでも２つのパターンがあり、１つは新しくline_foodを生成する場合。
もう１つはすでに同じfoodに関するline_foodが存在する場合で、
この判断をordered_food.line_food.present?で行っている。

ordered_food.line_food.present?がtrueの場合、
@line_food.attributes = {...で既存のline_foodインスタンスの既存の情報を更新します。
ここでは、countとactiveの２つを更新。

一方で、全く新しくline_foodを作成する場合はordered_food.build_line_food(...でインスタンスを新規作成。

### DBに保存
```rb
if @line_food.save
  render json: {
    line_food: @line_food
  }, status: :created
else
  render json: {}, status: :internal_server_error
end
```
@line_foodをsaveで保存。この時にエラーが発生した場合にはif @line_food.saveでfalseと判断され
render json: {}, status: :internal_server_errorが返る。
もしフロントエンドでエラーの内容に応じて表示を変えるような場合に
ここでHTTPレスポンスステータスコードが500系になることをチェックできる。

@line_food.saveが成功した場合、status: :createdと保存したデータを返します。

これで例外パターンを考慮したfoods_controller.rbの最初のアクションの定義が完了。

#### 最後に
before_actionではそのコントローラーのメインアクションに入る"前"におこおなう処理を挟むことができる。
これをcallbackという。
「早期リターン」とは複雑あるいは重いメイン処理を実行する前に、この処理が不要なケースに当てはまるかどうかをifなどでチェックし、その場合にメイン処理に入らせないことを指す


